### PR TITLE
Update template hook parameter to array and add metadata

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -8,6 +8,31 @@ class Plugin extends Base
 {
     public function initialize()
     {
-        $this->hook->on('template:layout:css', 'plugins/Css/skin.css');
+        $this->hook->on("template:layout:css", array("template" => "plugins/Css/skin.css"));
+    }
+
+    public function getPluginName()
+    {
+        return 'Css';
+    }
+
+    public function getPluginDescription()
+    {
+        return t('This plugin add a new stylesheet and override default styles.');
+    }
+
+    public function getPluginAuthor()
+    {
+        return 'Author';
+    }
+
+    public function getPluginVersion()
+    {
+        return '0.0.1';
+    }
+
+    public function getPluginHomepage()
+    {
+        return 'https://github.com/kanboard/plugin-example-css';
     }
 }


### PR DESCRIPTION
In the latest version of kanboard, the css asset hook takes an array as mentioned in the [documentation](https://github.com/kanboard/kanboard/blob/master/doc/plugin-hooks.markdown#asset-hooks) so this commit is updating the hook. 

And plugin metadata was added to encourage good practices. 
